### PR TITLE
Feature: Slack unfurling

### DIFF
--- a/views/layouts/app.haml
+++ b/views/layouts/app.haml
@@ -15,6 +15,9 @@
     %link{ :href => "/css/base.css", :rel => "stylesheet" }
     %link{ :href => "/css/bootstrap_override.css", :rel => "stylesheet" }
     %link{ :href => 'http://fonts.googleapis.com/css?family=Oxygen+Mono', :rel => 'stylesheet', :type => 'text/css' }
+    %link{ :property => "og:source", :content => "Chist" }
+    %link{ :property => "og:title", :content => "#{chist.user.name}/#{chist.title}" }
+    %link{ :property => "og:description", :content => chist.chist.lines[0..4].join("\n") }
   %body
     #wrap
       = partial 'shared/_header'

--- a/views/layouts/home.haml
+++ b/views/layouts/home.haml
@@ -11,6 +11,8 @@
     %link{ :href => "css/home.css", :rel => "stylesheet" }
     %link{ :href => "css/layout.css", :rel => "stylesheet" }
     %link{ :href => "http://fonts.googleapis.com/css?family=Inconsolata", :rel => "stylesheet", :type => "text/css" }
+    %link{ :property => "og:source", :content => "Chist" }
+    %link{ :property => "og:title", :content => "Chist: Share your chat with style" }
   %body
     #wrapper
       #container.container


### PR DESCRIPTION
Slack [unfurls links](https://api.slack.com/docs/unfurling), displaying some metadata about the linked site in the chat window. This `<meta>` elements will allow to display a preview when a chist link is pasted into Slack.
