### PR TITLE
Contact page

### DIFF
--- a/routes/chist.rb
+++ b/routes/chist.rb
@@ -36,6 +36,10 @@ class ChistApp::Routes < Cuba
       run ChistApp::Password
     end
 
+    on 'contact' do
+      run ChistApp::Contact
+    end
+
     on get do
       on root do
         if current_user
@@ -65,26 +69,7 @@ class ChistApp::Routes < Cuba
         }
       end
 
-      on 'contact' do
-        res.write render("./views/layouts/app.haml") {
-          render("./views/public/contact.haml", params: session.delete('contact.params') || {});
-        }
-      end
-
       not_found!
-    end
-
-    on post, 'contact' do
-      params = req.params['contact'].strip
-      ctx = ChistApp::Context::ContactForm.new(params, self)
-      case ctx.call
-      when :success
-        flash[:success] = I18n.t('contact.sent')
-      when :error
-        flash[:error] = ctx.error_message
-        session['contact.params'] = params
-      end
-      res.redirect "/contact"
     end
 
     not_found!

--- a/routes/contact.rb
+++ b/routes/contact.rb
@@ -1,0 +1,24 @@
+class ChistApp::Contact < Cuba
+  define do
+    on get, root do
+      res.write render("./views/layouts/app.haml") {
+        render("./views/public/contact.haml", params: session.delete('contact.params') || {});
+      }
+    end
+
+    on post, root do
+      params = req.params['contact'].strip
+      ctx = ChistApp::Context::ContactForm.new(params, self)
+      case ctx.call
+      when :success
+        flash[:success] = I18n.t('contact.sent')
+      when :error
+        flash[:error] = ctx.error_message
+        session['contact.params'] = params
+      end
+      res.redirect "/contact"
+    end
+
+    
+  end
+end

--- a/test/routes/contact_test.rb
+++ b/test/routes/contact_test.rb
@@ -1,0 +1,39 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
+
+describe ChistApp::Dashboard do
+
+  def setup
+    Contact.dataset.truncate
+  end
+
+  it 'should show contact page' do
+    get '/contact'
+
+    assert_equal 200, last_response.status
+  end
+
+  it 'should create conctact message' do
+    user = User.spawn(password: 'qwe123')
+    login(user, 'qwe123')
+
+    params = {
+      :contact => {
+        :name => "Ed Vedder",
+        :email => "ed@example.com",
+        :message => "Test Message",
+        :sample => "Some code"
+      }
+    }
+
+    post "/contact", params
+
+    contact = Contact.first
+
+    assert_equal 302, last_response.status
+    assert_equal 1, Contact.count
+    assert_equal params[:contact][:name], contact.name
+    assert_equal params[:contact][:email], contact.email
+    assert_equal params[:contact][:message], contact.message
+    assert_equal params[:contact][:sample], contact.sample
+  end
+end

--- a/views/public/contact.haml
+++ b/views/public/contact.haml
@@ -19,3 +19,10 @@
         = params['sample'] || ''
     .form-group
       %input.btn.btn-primary{type: 'submit', value: I18n.t('home.send')}
+
+
+.col-md-6.col-md-offset-1
+  %p
+    If you'd like support for an unsupported chat format, please provide an example of any given chat and we'll do our best to add support for it.
+
+    Remember not to expose any sensitive data in the example.


### PR DESCRIPTION
This PR moves contact routes to their own file.
It also adds a simple text to the contact form and adds tests for `GET` and `POST` routes.