### PR TITLE
Fixes Slack parser for new Slack format

### DIFF
--- a/lib/parser/slack_parser.rb
+++ b/lib/parser/slack_parser.rb
@@ -1,7 +1,7 @@
 class ChistApp::SlackParser
 
   def self.parse(log)
-    time_regexp = /^.+\s\[\d+:\d{2}\s[AMP]{2}\]\s*/
+    time_regexp = /^.*\s*\[\d+:\d{2}\s*[AMP]{2}*\]\s*/
 
     #scan for participants
     participants = log.scan(/(^.+\s\[\d+:\d{2}\s[AMP]{2}\])\s*$/).collect! {|scan| scan.first.split(" [").first }.uniq
@@ -18,8 +18,18 @@ class ChistApp::SlackParser
       time = line.scan(time_regexp)
 
       if time.any?
-        parsed = time.first.scan(/(^.+)(\s\[\d+:\d{2}\s[AMP]{2}\])/).first
-        username = "#{parsed.last.strip} #{parsed.first.strip}"
+        parsed = time.first.scan(/(^.+)(\s*\[\d+:\d{2}\s*[AMP]{2}*\])/).first
+
+        #Nasty trick to deal with invisible character inserted by scan
+        if parsed.first.strip.length > 1
+          @last_nickname = parsed.first.strip
+          @last_timestamp = parsed.last.strip
+        else
+          parsed.last.gsub!(/\[|\]/,"")
+          @last_timestamp.gsub!(/\d+:\d+/, parsed.last)
+        end
+
+        username = "#{@last_timestamp} #{@last_nickname}"
         next
       end
 


### PR DESCRIPTION
This PR fixes the parser for the Slack chat format.
Slack recently changed its timestamp format and chists were parsed incorrectly

I also had to add a nasty hack because not only Slack changed to an inconsistent format, but Ruby also do some weird invisible character insertion in `scan`.

![photo_2015-12-29_20-27-12](https://cloud.githubusercontent.com/assets/43977/12044155/ad9a1254-ae6b-11e5-81f8-4c558b000bd5.jpg)

There's an invisible difference shown here:
```
[6] pry(ChistApp::SlackParser)> URI.encode(parsed.first.strip)
=> "%E2%80%8B"
[7] pry(ChistApp::SlackParser)> URI.encode("")
=> ""
```

So, after all the bug haunting, the Slack chists are parsed correctly with this patch.