### PR TITLE
Chists API refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tags
 *.env.sh
 log/*.log
 log/*.pid
+.DS_Store

--- a/context/chist_creation.rb
+++ b/context/chist_creation.rb
@@ -17,7 +17,7 @@ module ChistApp::Context
           title:     @chist_params['title'],
           chist_raw: @chist_params['chist'].dup,
           chist:     ChistApp::Parser.parse(@chist_params['format'], @chist_params['chist']),
-          public:    @chist_params['public'].to_i == 1,
+          public:    @chist_params['public'],
           format:    @chist_params['format'],
           user:      @ctx.current_user
         })

--- a/context/chist_update.rb
+++ b/context/chist_update.rb
@@ -1,0 +1,31 @@
+module ChistApp::Context
+  class ChistUpdate
+    attr_reader :chist, :error_message
+
+    def initialize(chist, params, ctx)
+      @chist        = chist
+      @chist_params = params
+      @ctx          = ctx
+    end
+
+    def call
+      begin
+        chist_form = ChistApp::Validators::ChistForm.hatch(@chist_params)
+
+        raise ArgumentError.new(chist_form.errors.full_messages.join(', ')) unless chist_form.valid?
+
+        @chist.title = @chist_params['title']
+        @chist.chist_raw = @chist_params['chist'].dup
+        @chist.chist = ChistApp::Parser.parse(@chist_params['format'], @chist_params['chist'])
+        @chist.public = @chist_params['public']
+        @chist.format = @chist_params['format']
+        @chist.save
+
+        :success
+      rescue => e
+        @error_message = e.message
+        :error
+      end
+    end
+  end
+end

--- a/helpers/api_helper.rb
+++ b/helpers/api_helper.rb
@@ -2,8 +2,8 @@ module ChistApp::Helpers
   def json(body, headers = {})
     headers["Content-type"] = "application/json"
 
-    headers.keys.each do |k|
-      req[k] = headers[k]
+    headers.each do |k, v|
+      req[k] = v
     end
 
     res.write body.to_json

--- a/helpers/api_helper.rb
+++ b/helpers/api_helper.rb
@@ -1,0 +1,11 @@
+module ChistApp::Helpers
+  def json(body, headers = {})
+    headers["Content-type"] = "application/json"
+
+    headers.keys.each do |k|
+      req[k] = headers[k]
+    end
+
+    res.write body.to_json
+  end
+end

--- a/models/chist.rb
+++ b/models/chist.rb
@@ -7,6 +7,11 @@ class Chist < Sequel::Model
     super
   end
 
+  def before_save
+    self.public = force_boolean(self.public)
+    true
+  end
+
   def id
     if values[:id]
       super.gsub("-", "")
@@ -34,5 +39,20 @@ class Chist < Sequel::Model
       :created_at => created_at,
       :updated_at => updated_at
     }
+  end
+
+  private
+
+  def force_boolean(val)
+    case val.class
+    when Numeric
+      val == 0 ? false : true
+    when String
+      !val.strip.empty?
+    when Hash, Array
+      !val.empty?
+    else
+      !!val
+    end
   end
 end

--- a/models/chist.rb
+++ b/models/chist.rb
@@ -19,4 +19,20 @@ class Chist < Sequel::Model
     self.class.db["DELETE FROM user_favorites WHERE user_id = ? AND chist_id = ?", self.user_id, self.id].all
     self.destroy
   end
+
+  def url
+    "/chists/#{id}"
+  end
+
+  def to_hash
+    {
+      :id         => id,
+      :title      => title,
+      :url        => url,
+      :public     => self.public,
+      :format     => format,
+      :created_at => created_at,
+      :updated_at => updated_at
+    }
+  end
 end

--- a/routes/api.rb
+++ b/routes/api.rb
@@ -7,19 +7,23 @@ module ChistApp
         on 'chists' do
           attrs = chist_params_from_request
 
-          ctx = ChistApp::Context::ChistCreation.new(attrs["chist"], self)
+          ctx = ChistApp::Context::ChistCreation.new(attrs, self)
 
           result = ctx.call
 
           if result == :success
             body = { :chist => {
-                    :url => "#{ENV["SITE_URL"]}/chists/#{ctx.chist.id}",
-                    :created_at => Time.now } }
+                          :id         => ctx.chist.id,
+                          :title      => ctx.chist.title,
+                          :url        => "#{ENV["SITE_URL"]}/#{ctx.chist.url}",
+                          :created_at => Time.now }
+                   }
 
-            headers = { "Content-type" => "application/json",
-                        "Location" => body[:chist][:url] }
+            headers = { "Location" => body[:chist][:url] }
 
-            halt [201, headers, body.to_json]
+            res.status = 201
+
+            json(body, headers)
           else
             res.status = 500
             res.write("Internal Server Error")

--- a/routes/api.rb
+++ b/routes/api.rb
@@ -12,12 +12,7 @@ module ChistApp
           result = ctx.call
 
           if result == :success
-            body = { :chist => {
-                          :id         => ctx.chist.id,
-                          :title      => ctx.chist.title,
-                          :url        => "#{ENV["SITE_URL"]}/#{ctx.chist.url}",
-                          :created_at => Time.now }
-                   }
+            body = { :chist => ctx.chist.to_hash.merge(:url => "#{ENV["SITE_URL"]}/#{ctx.chist.url}") }
 
             headers = { "Location" => body[:chist][:url] }
 

--- a/routes/chists.rb
+++ b/routes/chists.rb
@@ -44,24 +44,17 @@ module ChistApp
             end
 
             on put, root do
-              begin
-                chist_params = req.params['chist']
-                chist_form = ChistApp::Validators::ChistForm.hatch(chist_params)
-
-                raise ArgumentError.new(chist_form.errors.full_messages.join(', ')) unless chist_form.valid?
-
-                chist.title = chist_params['title']
-                chist.chist_raw = chist_params['chist'].dup
-                chist.chist = ChistApp::Parser.parse(chist_params['format'], chist_params['chist'])
-                chist.public = chist_params['public']
-                chist.format = chist_params['format']
-                chist.save
+              ctx = ChistApp::Context::ChistUpdate.new(chist,
+                                                       req.params["chist"],
+                                                       self)
+              case ctx.call
+              when :success
                 flash[:success] = I18n.t('chists.chist_edited')
-                redirect! "/chists/#{chist.id}"
-              rescue => e
-                flash[:error] = e.message
-                chist_params.delete('chist')
-                session['chist.chist_params'] = chist_params
+                redirect! ctx.chist.url
+              when :error
+                flash[:error] = ctx.error_message
+                req.params['chist'].delete('chist')
+                session['chist.chist_params'] = req.params['chist']
                 redirect! "/chists/#{chist.id}/edit"
               end
             end

--- a/routes/chists.rb
+++ b/routes/chists.rb
@@ -53,7 +53,7 @@ module ChistApp
                 chist.title = chist_params['title']
                 chist.chist_raw = chist_params['chist'].dup
                 chist.chist = ChistApp::Parser.parse(chist_params['format'], chist_params['chist'])
-                chist.public = chist_params['public'].to_i == 1
+                chist.public = chist_params['public']
                 chist.format = chist_params['format']
                 chist.save
                 flash[:success] = I18n.t('chists.chist_edited')

--- a/test/routes/api/create_chist_test.rb
+++ b/test/routes/api/create_chist_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
+require File.expand_path(File.dirname(__FILE__)) + '/../../test_helper'
 
 describe 'ChistApp::ApiRoutes' do
   before do
@@ -62,6 +62,5 @@ describe 'ChistApp::ApiRoutes' do
 
     assert last_response.unauthorized?
     assert last_response.header["WWW-Authenticate"].include? "Digest"
-
   end
 end

--- a/test/routes/api/list_chists_test.rb
+++ b/test/routes/api/list_chists_test.rb
@@ -1,0 +1,47 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../../test_helper'
+
+describe 'ChistApp::ApiRoutes' do
+  before do
+    User.dataset.destroy
+    Chist.dataset.destroy
+    UserApiKey.dataset.destroy
+
+    @user = User.spawn
+    UserApiKey.create(:user_id => @user.id, :name => "Default", :key => "1234")
+  end
+
+  it 'should not take an API request without the auth header' do
+    get '/chists', {}
+    puts last_response
+
+    assert last_response.redirect?
+    last_response["Location"].must_equal "/404"
+  end
+
+  it 'should list authenticated user chists' do
+    headers = {
+      "CONTENT_TYPE" => "application/json",
+      "HTTP_ACCEPT" => "application/json",
+      "HTTP_AUTHORIZATION" => @user.user_api_keys[0].key
+    }
+
+    chists = [Chist.spawn(:user_id => @user.id),
+              Chist.spawn(:user_id => @user.id),
+              Chist.spawn(:user_id => @user.id)]
+
+
+    get "/chists", {}, headers
+
+    last_response.status.must_equal 200
+
+    response = JSON.parse(last_response.body)
+
+    assert response["chists"].is_a?(Array)
+
+    response["chists"].each do |c|
+      assert chists.map(&:title).include? c["title"]
+      assert chists.map(&:chist).include? c["chist"]
+      assert chists.map(&:user_id).include? c["user_id"]
+    end
+  end
+end

--- a/test/routes/chist_test.rb
+++ b/test/routes/chist_test.rb
@@ -59,7 +59,7 @@ describe ChistApp::Chists do
     chist.wont_be_nil
     new_title = Faker::Name.name
 
-    params = chist.to_hash.merge(title: new_title)
+    params = chist.values.merge(title: new_title)
     params.delete(:public)
     params.delete(:id)
     put "/chists/#{chist.id}", {chist: params}


### PR DESCRIPTION
This PR adds the POST route to API to create chists. It also refactors the GET route to list chists and how JSON responses are built.
It adds utility methods to `Chist` model to facilitate its JSON representation.
